### PR TITLE
resize stage to fit on r4.2xlarge

### DIFF
--- a/terraform-environments/aws/stage/helm/gem-backend/read-node/main.tf
+++ b/terraform-environments/aws/stage/helm/gem-backend/read-node/main.tf
@@ -8,9 +8,9 @@ locals {
   replica_count     = 1
   docker_repository = "283278994941.dkr.ecr.us-east-1.amazonaws.com/backend"
   docker_tag        = "v1.2.3"
-  requests_memory   = "64Gi"
-  requests_cpu      = "200"
-  # big boy
+  requests_memory   = "32Gi"
+  requests_cpu      = "100"
+  # medium boy
 
   tags = {
     ops_env              = "stage"

--- a/terraform-environments/aws/stage/helm/gem-backend/write-node/main.tf
+++ b/terraform-environments/aws/stage/helm/gem-backend/write-node/main.tf
@@ -8,9 +8,9 @@ locals {
   replica_count     = 1
   docker_repository = "283278994941.dkr.ecr.us-east-1.amazonaws.com/backend"
   docker_tag        = "v1.2.3"
-  requests_memory   = "64Gi"
-  requests_cpu      = "200"
-  # big boy
+  requests_memory   = "32Gi"
+  requests_cpu      = "100"
+  # medium boy
 
 
   tags = {


### PR DESCRIPTION
Our instance details:
r4.2xlarge: 61 GiB of memory, 8 vCPUs, 64-bit platform 