### PR TITLE
remove expose global state to fix remote state

### DIFF
--- a/terraform-environments/aws/dev/helm/gem-backend/helm_values.yaml
+++ b/terraform-environments/aws/dev/helm/gem-backend/helm_values.yaml
@@ -45,8 +45,6 @@ deployment:
           value: "${sqs_uri}"
         - name: GLOBAL_STATE_API_URL
           value: "https://node.deso.org"
-        - name: EXPOSE_GLOBAL_STATE
-          value: "true"
         - name: RUN_HOT_FEED_ROUTINE
           value: "true"
         - name: HOT_FEED_MEDIA_REQUIRED

--- a/terraform-environments/aws/stage/helm/gem-backend/helm_values.yaml
+++ b/terraform-environments/aws/stage/helm/gem-backend/helm_values.yaml
@@ -39,8 +39,6 @@ deployment:
           value: "${sqs_uri}"
         - name: GLOBAL_STATE_API_URL
           value: "https://node.deso.org"
-        - name: EXPOSE_GLOBAL_STATE
-          value: "true"
         - name: RUN_HOT_FEED_ROUTINE
           value: "true"
         - name: HOT_FEED_MEDIA_REQUIRED


### PR DESCRIPTION
From docs

Fully formed URL to use to fetch global state data. Only used if expose-global-state is false. If not provided, use own global state. The URL must point to another node that has true for its  value. This will allow you to fetch verified usernames, blacklist, graylist, and posts that have been added to the global feed on the requested URL.


Our global state was not working because we had expose global state set to true. We must disable that in order for remote state to work.